### PR TITLE
Don't disable tor-add button when "own" filter is enabled.

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -50,9 +50,7 @@ function blockActions() {
 		lock = 1;
 	} else {
 		$( "#topics_control" ).find( "button" ).prop( "disabled", false );
-		if ( ($subsections.val() !== "-3" && $subsections.val() < 1) || !$( "input[name=filter_status]" ).eq( 1 ).prop( "checked" ) ) {
-			$( "#tor_add" ).prop( "disabled", true );
-		} else {
+		if ( !($subsections.val() !== "-3" && $subsections.val() < 1) && $( "input[name=filter_status]" ).eq( 1 ).prop( "checked" ) ) {
 			$( ".torrent_action" ).prop( "disabled", true );
 		}
 		$subsections.attr( "disabled", false );

--- a/php/actions/get_filtered_list_topics.php
+++ b/php/actions/get_filtered_list_topics.php
@@ -218,7 +218,7 @@ try {
 			                     . $topic['ss'] . '" size="' . $topic['si']
 			                     . '" hash="' . $topic['hs'] . '" client="'
 			                     . $topic['cl'] . '" >',
-			"color"           => '<img title="" src="img/' . $icons . '.png">',
+			"color"           => '<img title="' . $topic['ds'] . '" src="img/' . $icons . '.png">',
 			"torrents_status" => $torrents_statuses[ $topic['st'] ],
 			"reg_date"        => date( 'd.m.Y', $topic['rg'] ),
 			"size"            => convert_bytes( $topic['si'] ),


### PR DESCRIPTION
This button works fine in the case described and it could be very useful for relocating the stored material between torrent-clients.
More detailed explanation in the forum post 73554454.